### PR TITLE
chore(traits): remove example trait from `main` branch

### DIFF
--- a/Contents/mods/OverkillTraits/42/media/registries.lua
+++ b/Contents/mods/OverkillTraits/42/media/registries.lua
@@ -5,7 +5,6 @@ OTAP = OTAP or {}
 --Character Traits
 
 OTAP.CharacterTrait = {
-    Example         = CharacterTrait.register("otap:example"),
     Kleptomania     = CharacterTrait.register("otap:kleptomania"),
     Pyromania       = CharacterTrait.register("otap:pyromania"),
     Sanguinarian    = CharacterTrait.register("otap:sanguinarian"),

--- a/Contents/mods/OverkillTraits/42/media/scripts/OTAPTraits.txt
+++ b/Contents/mods/OverkillTraits/42/media/scripts/OTAPTraits.txt
@@ -1,16 +1,4 @@
 module OTAP {
-    character_trait_definition otap:example{
-        CharacterTrait          = otap:example,
-        UIName                  = Example,
-        Cost                    = 12,
-        UIDescription           = Example mod only left in as a baseplate,
-        IsProfessionTrait       = false,
-        DisabledInMultiplayer   = false,
-        GrantedRecipes          = MakeSawPlank,
-        GrantedTraits           = base:smoker,
-        XPBoosts                = Aiming=1;Reloading=1,
-        MutuallyExclusiveTraits = base:clumsy;base:deaf,
-    }
     character_trait_definition otap:kleptomania{
         CharacterTrait          = otap:kleptomania,
         UIName                  = Kleptomania,


### PR DESCRIPTION
Removing the example trait from the main branch, so it only exists on the development branches